### PR TITLE
feat: add .jks and .keystore to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ app.*.map.json
 
 # environment file
 env/
+
+# Keystore files
+*.jks
+*.keystore


### PR DESCRIPTION
This commit updates the `.gitignore` file to exclude `.jks` and `.keystore` files from being tracked by Git. These files are commonly used for storing signing keys and should not be committed to the repository.